### PR TITLE
Adding new endpoints for GuardianTheaterSlackBot

### DIFF
--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -9,6 +9,8 @@ let GET = [
         { name: 'Account', url: '${ membershipType }/Account/${ membershipId }/', required: ['membershipType', 'membershipId'] },
         { name: 'Character', url: '${ membershipType }/Account/${ membershipId }/Character/${ characterId }/', required: ['membershipType', 'membershipId', 'characterId'] },
         { name: 'Activities', url: '${ membershipType }/Account/${ membershipId }/Character/${ characterId }/Activities/', required: ['membershipType', 'membershipId', 'characterId'] },
+        { name: 'ActivityHistory', url: '/Stats/ActivityHistory/${ membershipType }/${ membershipId }/${ characterId }/?definitions=true&mode=${ mode }',  required: ['membershipType', 'membershipId', 'characterId', 'mode'] },
+        { name: 'CarnageReport', url: '/Stats/PostGameCarnageReport/${ activityId }/',  required: ['activityId'] },
         { name: 'Inventory', url: '${ membershipType }/Account/${ membershipId }/Character/${ characterId }/Inventory/', required: ['membershipType', 'membershipId', 'characterId'] },
         { name: 'Progression', url: '${ membershipType }/Account/${ membershipId }/Character/${ characterId }/Progression/', required: ['membershipType', 'membershipId', 'characterId'] }
     ].map(UTILS.assignMap({ options: { method: UTILS.METHODS.GET, headers: UTILS.HEADERS } }));


### PR DESCRIPTION
The two new endpoints are vital in assisting the GuardianTheaterSlackBot in querying the nessecary information to become functional.

`{ name: 'ActivityHistory', url: '/Stats/ActivityHistory/${ membershipType }/${ membershipId }/${ characterId }/?definitions=true&mode=${ mode }',  required: ['membershipType', 'membershipId', 'characterId', 'mode'] },        
{ name: 'CarnageReport', url: '/Stats/PostGameCarnageReport/${ activityId }/',  required: ['activityId'] },`

https://github.com/dasilva333/GuardianTheaterSlackbot

Thanks!
